### PR TITLE
feat: add account-map bypass support for static account mappings

### DIFF
--- a/src/providers.tf
+++ b/src/providers.tf
@@ -17,3 +17,48 @@ module "iam_roles" {
   source  = "../../account-map/modules/iam-roles"
   context = module.this.context
 }
+
+variable "account_map_enabled" {
+  type        = bool
+  description = <<-EOT
+    When true, uses the account-map component to look up account IDs dynamically.
+    When false, uses the static account_map variable instead. Set to false when
+    using static account mappings without the account-map component.
+  EOT
+  default     = true
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map           = map(string)
+    audit_account_account_name = optional(string, "")
+    root_account_account_name  = optional(string, "")
+  })
+  description = <<-EOT
+    Static account map used when account_map_enabled is false.
+    Provides account name to account ID mapping without requiring the account-map component.
+  EOT
+  default = {
+    full_account_map           = {}
+    audit_account_account_name = ""
+    root_account_account_name  = ""
+  }
+}
+
+variable "account_map_tenant" {
+  type        = string
+  description = "The name of the tenant where `account_map` is provisioned"
+  default     = "core"
+}
+
+variable "account_map_environment" {
+  type        = string
+  description = "The name of the environment where `account_map` is provisioned"
+  default     = "gbl"
+}
+
+variable "account_map_stage" {
+  type        = string
+  description = "The name of the stage where `account_map` is provisioned"
+  default     = "root"
+}

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -44,21 +44,3 @@ variable "account_map" {
     root_account_account_name  = ""
   }
 }
-
-variable "account_map_tenant" {
-  type        = string
-  description = "The name of the tenant where `account_map` is provisioned"
-  default     = "core"
-}
-
-variable "account_map_environment" {
-  type        = string
-  description = "The name of the environment where `account_map` is provisioned"
-  default     = "gbl"
-}
-
-variable "account_map_stage" {
-  type        = string
-  description = "The name of the stage where `account_map` is provisioned"
-  default     = "root"
-}

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -3,11 +3,15 @@ module "account_map" {
   version = "1.8.0"
 
   component   = "account-map"
-  tenant      = var.account_map_tenant_name
-  environment = var.account_map_environment_name
-  stage       = var.account_map_stage_name
+  tenant      = var.account_map_enabled ? coalesce(var.account_map_tenant, module.this.tenant) : null
+  environment = var.account_map_enabled ? var.account_map_environment : null
+  stage       = var.account_map_enabled ? var.account_map_stage : null
 
   context = module.this.context
+
+  # When account_map is disabled, bypass remote state and use the static account_map variable
+  bypass   = !var.account_map_enabled
+  defaults = var.account_map
 }
 
 module "vpc" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -24,6 +24,23 @@ variable "grafana_account_name" {
   default     = ""
 }
 
+variable "account_map_tenant" {
+  type        = string
+  description = "The name of the tenant where `account_map` is provisioned"
+  default     = "core"
+}
+
+variable "account_map_environment" {
+  type        = string
+  description = "The name of the environment where `account_map` is provisioned"
+  default     = "gbl"
+}
+
+variable "account_map_stage" {
+  type        = string
+  description = "The name of the stage where `account_map` is provisioned"
+  default     = "root"
+}
 
 variable "vpc_endpoint_enabled" {
   type        = string

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -24,19 +24,46 @@ variable "grafana_account_name" {
   default     = ""
 }
 
-variable "account_map_tenant_name" {
+variable "account_map_enabled" {
+  type        = bool
+  description = <<-EOT
+    When true, uses the account-map component to look up account IDs dynamically.
+    When false, uses the static account_map variable instead. Set to false when
+    using static account mappings without the account-map component.
+  EOT
+  default     = true
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map           = map(string)
+    audit_account_account_name = optional(string, "")
+    root_account_account_name  = optional(string, "")
+  })
+  description = <<-EOT
+    Static account map used when account_map_enabled is false.
+    Provides account name to account ID mapping without requiring the account-map component.
+  EOT
+  default = {
+    full_account_map           = {}
+    audit_account_account_name = ""
+    root_account_account_name  = ""
+  }
+}
+
+variable "account_map_tenant" {
   type        = string
   description = "The name of the tenant where `account_map` is provisioned"
   default     = "core"
 }
 
-variable "account_map_environment_name" {
+variable "account_map_environment" {
   type        = string
   description = "The name of the environment where `account_map` is provisioned"
   default     = "gbl"
 }
 
-variable "account_map_stage_name" {
+variable "account_map_stage" {
   type        = string
   description = "The name of the stage where `account_map` is provisioned"
   default     = "root"

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -24,50 +24,6 @@ variable "grafana_account_name" {
   default     = ""
 }
 
-variable "account_map_enabled" {
-  type        = bool
-  description = <<-EOT
-    When true, uses the account-map component to look up account IDs dynamically.
-    When false, uses the static account_map variable instead. Set to false when
-    using static account mappings without the account-map component.
-  EOT
-  default     = true
-}
-
-variable "account_map" {
-  type = object({
-    full_account_map           = map(string)
-    audit_account_account_name = optional(string, "")
-    root_account_account_name  = optional(string, "")
-  })
-  description = <<-EOT
-    Static account map used when account_map_enabled is false.
-    Provides account name to account ID mapping without requiring the account-map component.
-  EOT
-  default = {
-    full_account_map           = {}
-    audit_account_account_name = ""
-    root_account_account_name  = ""
-  }
-}
-
-variable "account_map_tenant" {
-  type        = string
-  description = "The name of the tenant where `account_map` is provisioned"
-  default     = "core"
-}
-
-variable "account_map_environment" {
-  type        = string
-  description = "The name of the environment where `account_map` is provisioned"
-  default     = "gbl"
-}
-
-variable "account_map_stage" {
-  type        = string
-  description = "The name of the stage where `account_map` is provisioned"
-  default     = "root"
-}
 
 variable "vpc_endpoint_enabled" {
   type        = string


### PR DESCRIPTION
## What
Add `account_map_enabled` and `account_map` variables to support bypassing the account-map remote state lookup.

## Why
Components that depend on `account-map` for account ID lookups require the account-map component to be deployed in remote state. This creates a hard dependency that makes testing, bootstrapping, and environments using static account mappings (e.g. with Atmos Auth) more complex.

The bypass pattern uses the remote-state module's `bypass` and `defaults` parameters to make the account-map dependency optional. When `account_map_enabled = false`, the component uses a static `account_map` variable instead of looking up remote state.

## References
- Follows the same bypass pattern used in other components (e.g. `aws-cloudtrail`, `aws-tfstate-backend`)
- Uses `bypass` and `defaults` parameters from `cloudposse/stack-config/yaml//modules/remote-state`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime toggle for account mapping and a configurable account-map object with defaults.
  * Remote-state behavior now supports bypassing account-map when disabled.

* **Refactor**
  * Renamed several account-map configuration fields for clarity.
  * Module inputs updated to conditionally populate tenant/environment/stage from account-map when enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->