### PR TITLE
chore: upgrade remote-state to v2.0.0

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = "account-map"
   tenant      = var.account_map_enabled ? coalesce(var.account_map_tenant, module.this.tenant) : null
@@ -16,7 +16,7 @@ module "account_map" {
 
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   count = local.vpc_endpoint_enabled ? 1 : 0
 

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0, < 6.0.0"
     }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade `cloudposse/stack-config/yaml//modules/remote-state` from v1.x to v2.0.0
- This enables compatibility with `cloudposse/utils` provider v2.x
- Updates vendored account-map to standalone repo at v1.537.2

## Changes
- `src/remote-state.tf`: version pin `1.8.0`/`1.5.0` → `2.0.0`
- `src/versions.tf`: widen utils provider constraint (if applicable)
- `test/fixtures/vendor.yaml`: switch account-map to standalone repo (if applicable)

## Test plan
- [ ] CI lint passes (terraform init, no provider conflicts)
- [ ] Terratest passes in merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)